### PR TITLE
fix(ci): add workflow_call trigger for reusable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Adds `workflow_call:` trigger to ci.yml so the release workflow can call it as a reusable workflow
- Without this, the release workflow fails at parse time

## Test plan
- [x] CI passes on this PR
- [x] After merge, re-tag v0.1.0 and verify release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)