### PR TITLE
ci: add PR title conventional commit check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            ci
+            refactor
+            test
+            chore
+          requireScope: false


### PR DESCRIPTION
## Summary
- Validates PR titles match conventional commit format: `type([scope]): description`
- Allowed types: feat, fix, docs, ci, refactor, test, chore
- Scope is optional
- Runs on PR open, edit, and synchronize

## Test plan
- [x] This PR's title passes the check
- [x] After merge, can be added as a required status check in branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)