### PR TITLE
fix: correct project slug computation

### DIFF
--- a/scripts/find_session.py
+++ b/scripts/find_session.py
@@ -28,7 +28,7 @@ HISTORY_FILE = Path.home() / ".claude" / "history.jsonl"
 
 
 def find_recent(project_dir):
-    slug = project_dir.lstrip("/").replace("/", "-")
+    slug = project_dir.replace("/", "-")
     project_path = CLAUDE_PROJECTS_DIR / slug
     if not project_path.is_dir():
         return None

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -8,7 +8,7 @@ from scripts.find_session import find_by_uuid, find_recent, list_sessions
 
 class TestFindRecent:
     def test_finds_most_recent_jsonl(self, tmp_path, monkeypatch):
-        slug = "home-user-myproject"
+        slug = "-home-user-myproject"
         project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
 
@@ -29,15 +29,15 @@ class TestFindRecent:
         assert find_recent("/nonexistent/project") is None
 
     def test_returns_none_for_empty_project_dir(self, tmp_path, monkeypatch):
-        slug = "home-user-emptyproject"
+        slug = "-home-user-emptyproject"
         project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
 
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
         assert find_recent("/home/user/emptyproject") is None
 
-    def test_strips_leading_slash_from_path(self, tmp_path, monkeypatch):
-        slug = "home-user-project"
+    def test_converts_path_to_slug(self, tmp_path, monkeypatch):
+        slug = "-home-user-project"
         project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
         f = project_dir / "abc.jsonl"
@@ -48,7 +48,7 @@ class TestFindRecent:
         assert result is not None
 
     def test_ignores_non_jsonl_files(self, tmp_path, monkeypatch):
-        slug = "home-user-proj"
+        slug = "-home-user-proj"
         project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
         (project_dir / "notes.txt").write_text("not a jsonl")


### PR DESCRIPTION
## Summary
- Claude Code names project directories with a leading dash (e.g., `-home-user-project`), but `find_recent()` was stripping the leading `/` before replacing with `-`, producing `home-user-project` — which never matched any directory
- This caused `/skillify this` (Mode A) to always fall through to the session picker
- Fix: use `replace("/", "-")` without `lstrip("/")` first

## Test plan
- [x] All 16 existing tests updated and passing
- [x] Run `/skillify this` and verify it auto-selects the most recent session instead of showing a picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)