### PR TITLE
feat: improve session resolution with named sessions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -39,12 +39,13 @@ Convert a Claude Code conversation — where the user iterated on automating a t
 
 Resolve the source conversation JSONL file. Check these modes **in order** — use the FIRST one that matches and do NOT fall through to later modes.
 
-**Mode A — Current session (MANDATORY when arguments are empty or say "this"):**
-If `$ARGUMENTS` is empty, blank, unset, OR contains "this", "current", or "this conversation": use the current session. Do NOT show a picker. Do NOT ask the user to choose. Immediately resolve the JSONL path:
+**Mode A — "this" (auto-select most recent session):**
+If `$ARGUMENTS` contains "this", "current", or "this conversation": auto-select the most recent session for the current project directory. Do NOT show a picker.
+
 ```
 python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode recent --project-dir "$PWD"
 ```
-Parse the JSON output for the `path` field. If found, proceed directly to Step 2.
+Parse the JSON output for the `path` field. If not found (exit code 1), fall through to Mode D (interactive picker).
 
 **Mode B — Explicit session ID:**
 Only if `$ARGUMENTS` contains a UUID (pattern: `[0-9a-f-]{36}`):
@@ -53,15 +54,25 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode uuid --session-id "$A
 ```
 Parse the JSON output for the `path` field. If not found (exit code 1), tell the user and ask for a different session ID.
 
-**Mode C — Interactive picker:**
-Only if `$ARGUMENTS` contains text that is NOT empty and NOT "this"/"current" and NOT a UUID:
-1. List the 10 most recent unique sessions:
+**Mode C — Named session (from /rename):**
+Only if `$ARGUMENTS` contains text that is NOT empty, NOT "this"/"current", and NOT a UUID:
+```
+python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode name --session-name "$ARGUMENTS"
+```
+Parse the JSON output for the `path` field. If not found (exit code 1), fall through to Mode D (interactive picker).
+
+**Mode D — Interactive picker:**
+If `$ARGUMENTS` is empty, blank, or unset — OR if Mode A/C fell through because no session was found:
+1. List recent sessions:
    ```
    python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode list
    ```
-   Parse the JSON array output — each entry has `session_id`, `timestamp`, and `display` fields.
-2. Present the list and let the user pick via AskUserQuestion.
-3. Locate the selected session's JSONL file using mode B with the chosen session_id.
+   Parse the JSON array output — each entry has `session_id`, `timestamp`, `display`, and `project` fields.
+2. Present the list via AskUserQuestion. Format each option as `{timestamp} [{project}] {display}` so the user can identify sessions by time, project directory, and description.
+3. Locate the selected session's JSONL file:
+   ```
+   python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode uuid --session-id "{SELECTED_SESSION_ID}"
+   ```
 
 **Success criteria:** A valid JSONL file path is identified.
 

--- a/scripts/find_session.py
+++ b/scripts/find_session.py
@@ -2,18 +2,22 @@
 """Resolve a Claude Code conversation JSONL file.
 
 Modes:
+  parent    Find the parent session (most recent in history, excluding current fork).
   recent    Find the most recent JSONL for a project directory.
   uuid      Find a JSONL by session UUID.
+  name      Find a session by custom title or agent name (from /rename).
   list      List the 10 most recent unique sessions.
 
 Usage:
+  python3 find_session.py --mode parent --exclude-session <fork-session-id>
   python3 find_session.py --mode recent --project-dir /path/to/project
   python3 find_session.py --mode uuid --session-id <uuid>
+  python3 find_session.py --mode name --session-name <name>
   python3 find_session.py --mode list
 
 Output (JSON to stdout):
-  recent/uuid: {"path": "/absolute/path/to/session.jsonl"}
-  list:        [{"session_id": "...", "timestamp": "...", "display": "..."}, ...]
+  recent/uuid/name: {"path": "/absolute/path/to/session.jsonl"}
+  list:             [{"session_id": "...", "timestamp": "...", "display": "...", "project": "..."}, ...]
 """
 
 import argparse
@@ -27,13 +31,41 @@ CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 HISTORY_FILE = Path.home() / ".claude" / "history.jsonl"
 
 
-def find_recent(project_dir):
+def find_parent(exclude_session):
+    if not HISTORY_FILE.exists():
+        return None
+    with open(HISTORY_FILE) as f:
+        lines = f.readlines()
+    seen = set()
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        sid = d.get("sessionId", "")
+        if not sid or sid in seen or sid == exclude_session:
+            continue
+        path = find_by_uuid(sid)
+        if path:
+            return path
+        seen.add(sid)
+    return None
+
+
+def find_recent(project_dir, exclude_session=None):
     slug = project_dir.replace("/", "-")
     project_path = CLAUDE_PROJECTS_DIR / slug
     if not project_path.is_dir():
         return None
     jsonl_files = sorted(project_path.glob("*.jsonl"), key=os.path.getmtime, reverse=True)
-    return str(jsonl_files[0]) if jsonl_files else None
+    for f in jsonl_files:
+        if exclude_session and f.stem == exclude_session:
+            continue
+        return str(f)
+    return None
 
 
 def find_by_uuid(session_id):
@@ -44,7 +76,76 @@ def find_by_uuid(session_id):
     return None
 
 
-def list_sessions(count=10):
+def get_first_user_message(session_id):
+    path = find_by_uuid(session_id)
+    if not path:
+        return None
+    try:
+        with open(path) as f:
+            for raw_line in f:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    entry = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") != "user":
+                    continue
+                msg = entry.get("message", {})
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list):
+                    text = " ".join(
+                        b.get("text", "")
+                        for b in content
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    )
+                else:
+                    continue
+                text = text.strip()
+                if text and not text.startswith("<"):
+                    return text[:120]
+    except OSError:
+        pass
+    return None
+
+
+def find_by_name(name):
+    name_lower = name.lower().strip()
+    if not CLAUDE_PROJECTS_DIR.is_dir():
+        return None
+    for dirpath, _, filenames in os.walk(CLAUDE_PROJECTS_DIR):
+        for fname in filenames:
+            if not fname.endswith(".jsonl"):
+                continue
+            path = os.path.join(dirpath, fname)
+            try:
+                with open(path) as f:
+                    for raw_line in f:
+                        raw_line = raw_line.strip()
+                        if not raw_line:
+                            continue
+                        try:
+                            entry = json.loads(raw_line)
+                        except json.JSONDecodeError:
+                            continue
+                        entry_type = entry.get("type", "")
+                        if entry_type == "custom-title":
+                            title = entry.get("customTitle", "")
+                            if title.lower().strip() == name_lower:
+                                return path
+                        elif entry_type == "agent-name":
+                            agent = entry.get("agentName", "")
+                            if agent.lower().strip() == name_lower:
+                                return path
+            except OSError:
+                continue
+    return None
+
+
+def list_sessions(count=10, exclude_session=None):
     if not HISTORY_FILE.exists():
         print("History file not found: " + str(HISTORY_FILE), file=sys.stderr)
         return []
@@ -61,13 +162,20 @@ def list_sessions(count=10):
         except json.JSONDecodeError:
             continue
         sid = d.get("sessionId", "")
-        if not sid or sid in seen:
+        if not sid or sid in seen or sid == exclude_session:
             continue
         seen.add(sid)
         ts = d.get("timestamp", 0)
         dt = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d %H:%M")
-        display = d.get("display", "")[:80]
-        sessions.append({"session_id": sid, "timestamp": dt, "display": display})
+        first_msg = get_first_user_message(sid)
+        display = first_msg if first_msg else d.get("display", "")[:80]
+        project = d.get("project", "")
+        sessions.append({
+            "session_id": sid,
+            "timestamp": dt,
+            "display": display,
+            "project": project,
+        })
         if len(sessions) >= count:
             break
     return sessions
@@ -75,16 +183,32 @@ def list_sessions(count=10):
 
 def main():
     parser = argparse.ArgumentParser(description="Resolve Claude Code conversation JSONL files")
-    parser.add_argument("--mode", required=True, choices=["recent", "uuid", "list"])
+    parser.add_argument("--mode", required=True, choices=["parent", "recent", "uuid", "name", "list"])
     parser.add_argument("--project-dir", help="Project directory (for recent mode)")
     parser.add_argument("--session-id", help="Session UUID (for uuid mode)")
+    parser.add_argument("--session-name", help="Session name (for name mode)")
+    parser.add_argument(
+        "--exclude-session",
+        help="Session ID to skip (for parent/recent mode)",
+    )
     args = parser.parse_args()
 
-    if args.mode == "recent":
+    if args.mode == "parent":
+        if not args.exclude_session:
+            print("--exclude-session required for parent mode", file=sys.stderr)
+            sys.exit(1)
+        path = find_parent(args.exclude_session)
+        if path:
+            json.dump({"path": path}, sys.stdout)
+        else:
+            print("No parent session found", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.mode == "recent":
         if not args.project_dir:
             print("--project-dir required for recent mode", file=sys.stderr)
             sys.exit(1)
-        path = find_recent(args.project_dir)
+        path = find_recent(args.project_dir, exclude_session=args.exclude_session)
         if path:
             json.dump({"path": path}, sys.stdout)
         else:
@@ -102,8 +226,19 @@ def main():
             print("Session not found: " + args.session_id, file=sys.stderr)
             sys.exit(1)
 
+    elif args.mode == "name":
+        if not args.session_name:
+            print("--session-name required for name mode", file=sys.stderr)
+            sys.exit(1)
+        path = find_by_name(args.session_name)
+        if path:
+            json.dump({"path": path}, sys.stdout)
+        else:
+            print("Session not found with name: " + args.session_name, file=sys.stderr)
+            sys.exit(1)
+
     elif args.mode == "list":
-        sessions = list_sessions()
+        sessions = list_sessions(exclude_session=args.exclude_session)
         if sessions:
             json.dump(sessions, sys.stdout, indent=2)
         else:

--- a/scripts/find_session.py
+++ b/scripts/find_session.py
@@ -17,7 +17,8 @@ Usage:
 
 Output (JSON to stdout):
   recent/uuid/name: {"path": "/absolute/path/to/session.jsonl"}
-  list:             [{"session_id": "...", "timestamp": "...", "display": "...", "project": "..."}, ...]
+  list:             [{"session_id": "...", "timestamp": "...",
+                      "display": "...", "project": "..."}, ...]
 """
 
 import argparse
@@ -183,7 +184,8 @@ def list_sessions(count=10, exclude_session=None):
 
 def main():
     parser = argparse.ArgumentParser(description="Resolve Claude Code conversation JSONL files")
-    parser.add_argument("--mode", required=True, choices=["parent", "recent", "uuid", "name", "list"])
+    modes = ["parent", "recent", "uuid", "name", "list"]
+    parser.add_argument("--mode", required=True, choices=modes)
     parser.add_argument("--project-dir", help="Project directory (for recent mode)")
     parser.add_argument("--session-id", help="Session UUID (for uuid mode)")
     parser.add_argument("--session-name", help="Session name (for name mode)")

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -162,7 +162,8 @@ class TestGetFirstUserMessage:
         project_dir = tmp_path / "projects" / "test"
         project_dir.mkdir(parents=True)
         self._write_session(project_dir / "sess-2.jsonl", [
-            {"type": "user", "message": {"role": "human", "content": "<ide_opened_file>foo</ide_opened_file>"}},
+            {"type": "user", "message": {"role": "human",
+                "content": "<ide_opened_file>foo</ide_opened_file>"}},
             {"type": "user", "message": {"role": "human", "content": "Real question here"}},
         ])
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -3,7 +3,14 @@
 import json
 import os
 
-from scripts.find_session import find_by_uuid, find_recent, list_sessions
+from scripts.find_session import (
+    find_by_name,
+    find_by_uuid,
+    find_parent,
+    find_recent,
+    get_first_user_message,
+    list_sessions,
+)
 
 
 class TestFindRecent:
@@ -47,6 +54,33 @@ class TestFindRecent:
         result = find_recent("/home/user/project")
         assert result is not None
 
+    def test_exclude_session_skips_most_recent(self, tmp_path, monkeypatch):
+        slug = "-home-user-myproject"
+        project_dir = tmp_path / "projects" / slug
+        project_dir.mkdir(parents=True)
+
+        old = project_dir / "source-session.jsonl"
+        old.write_text("{}")
+        fork = project_dir / "fork-session.jsonl"
+        fork.write_text("{}")
+        os.utime(old, (1000, 1000))
+        os.utime(fork, (2000, 2000))
+
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = find_recent("/home/user/myproject", exclude_session="fork-session")
+        assert result == str(old)
+
+    def test_exclude_session_returns_none_if_only_match(self, tmp_path, monkeypatch):
+        slug = "-home-user-myproject"
+        project_dir = tmp_path / "projects" / slug
+        project_dir.mkdir(parents=True)
+
+        only = project_dir / "only-session.jsonl"
+        only.write_text("{}")
+
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert find_recent("/home/user/myproject", exclude_session="only-session") is None
+
     def test_ignores_non_jsonl_files(self, tmp_path, monkeypatch):
         slug = "-home-user-proj"
         project_dir = tmp_path / "projects" / slug
@@ -55,6 +89,109 @@ class TestFindRecent:
 
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
         assert find_recent("/home/user/proj") is None
+
+
+class TestFindParent:
+    def _write_history(self, history_file, entries):
+        with open(history_file, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def test_finds_parent_session(self, tmp_path, monkeypatch):
+        history = tmp_path / "history.jsonl"
+        self._write_history(history, [
+            {"sessionId": "parent-id", "timestamp": 1700000000000, "display": "Parent"},
+            {"sessionId": "fork-id", "timestamp": 1700001000000, "display": "Fork"},
+        ])
+        project_dir = tmp_path / "projects" / "some-project"
+        project_dir.mkdir(parents=True)
+        (project_dir / "parent-id.jsonl").write_text("{}")
+        (project_dir / "fork-id.jsonl").write_text("{}")
+
+        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = find_parent("fork-id")
+        assert result.endswith("parent-id.jsonl")
+
+    def test_skips_fork_session(self, tmp_path, monkeypatch):
+        history = tmp_path / "history.jsonl"
+        self._write_history(history, [
+            {"sessionId": "fork-id", "timestamp": 1700001000000, "display": "Fork"},
+        ])
+        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert find_parent("fork-id") is None
+
+    def test_returns_none_for_missing_history(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", tmp_path / "nonexistent.jsonl")
+        assert find_parent("fork-id") is None
+
+    def test_skips_sessions_without_jsonl(self, tmp_path, monkeypatch):
+        history = tmp_path / "history.jsonl"
+        self._write_history(history, [
+            {"sessionId": "no-file", "timestamp": 1700001000000, "display": "No file"},
+            {"sessionId": "has-file", "timestamp": 1700000000000, "display": "Has file"},
+        ])
+        project_dir = tmp_path / "projects" / "some-project"
+        project_dir.mkdir(parents=True)
+        (project_dir / "has-file.jsonl").write_text("{}")
+
+        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = find_parent("fork-id")
+        assert result.endswith("has-file.jsonl")
+
+
+class TestGetFirstUserMessage:
+    def _write_session(self, path, entries):
+        with open(path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def test_extracts_first_user_message(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-1.jsonl", [
+            {"type": "system", "content": "system msg"},
+            {"type": "user", "message": {"role": "human", "content": "Hello world"}},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert get_first_user_message("sess-1") == "Hello world"
+
+    def test_skips_xml_tagged_messages(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-2.jsonl", [
+            {"type": "user", "message": {"role": "human", "content": "<ide_opened_file>foo</ide_opened_file>"}},
+            {"type": "user", "message": {"role": "human", "content": "Real question here"}},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert get_first_user_message("sess-2") == "Real question here"
+
+    def test_returns_none_for_missing_session(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert get_first_user_message("nonexistent") is None
+
+    def test_truncates_long_messages(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-3.jsonl", [
+            {"type": "user", "message": {"role": "human", "content": "x" * 200}},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert len(get_first_user_message("sess-3")) == 120
+
+    def test_handles_list_content(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-4.jsonl", [
+            {"type": "user", "message": {"role": "human", "content": [
+                {"type": "text", "text": "Part one"},
+                {"type": "text", "text": "part two"},
+            ]}},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert get_first_user_message("sess-4") == "Part one part two"
 
 
 class TestFindByUuid:
@@ -84,6 +221,63 @@ class TestFindByUuid:
         assert result == str(target)
 
 
+class TestFindByName:
+    def _write_session(self, path, entries):
+        with open(path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def test_finds_by_custom_title(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-1.jsonl", [
+            {"type": "user", "message": {"role": "human", "content": "hello"}},
+            {"type": "custom-title", "customTitle": "sprint-status-skill"},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = find_by_name("sprint-status-skill")
+        assert result.endswith("sess-1.jsonl")
+
+    def test_finds_by_agent_name(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-2.jsonl", [
+            {"type": "agent-name", "agentName": "weekly-rollup"},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = find_by_name("weekly-rollup")
+        assert result.endswith("sess-2.jsonl")
+
+    def test_case_insensitive(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-3.jsonl", [
+            {"type": "custom-title", "customTitle": "Sprint-Status-Skill"},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert find_by_name("sprint-status-skill") is not None
+
+    def test_returns_none_for_no_match(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        self._write_session(project_dir / "sess-4.jsonl", [
+            {"type": "custom-title", "customTitle": "other-skill"},
+        ])
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert find_by_name("sprint-status-skill") is None
+
+    def test_returns_none_for_empty_projects_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "nonexistent")
+        assert find_by_name("anything") is None
+
+    def test_skips_non_jsonl_files(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects" / "test"
+        project_dir.mkdir(parents=True)
+        (project_dir / "notes.txt").write_text('{"type":"custom-title","customTitle":"match"}')
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        assert find_by_name("match") is None
+
+
 class TestListSessions:
     def _write_history(self, history_file, entries):
         with open(history_file, "w") as f:
@@ -102,6 +296,20 @@ class TestListSessions:
         assert len(sessions) == 2
         assert sessions[0]["session_id"] == "bbb"
         assert sessions[1]["session_id"] == "aaa"
+
+    def test_excludes_session(self, tmp_path, monkeypatch):
+        history = tmp_path / "history.jsonl"
+        self._write_history(history, [
+            {"sessionId": "aaa", "timestamp": 1700000000000, "display": "First"},
+            {"sessionId": "fork", "timestamp": 1700001000000, "display": "Fork"},
+            {"sessionId": "bbb", "timestamp": 1700002000000, "display": "Second"},
+        ])
+        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
+
+        sessions = list_sessions(exclude_session="fork")
+        assert len(sessions) == 2
+        ids = [s["session_id"] for s in sessions]
+        assert "fork" not in ids
 
     def test_deduplicates_sessions(self, tmp_path, monkeypatch):
         history = tmp_path / "history.jsonl"


### PR DESCRIPTION
## Summary
- Add `find_parent()`, `get_first_user_message()`, and `find_by_name()` to `find_session.py`
- Session picker now shows the first user message from the JSONL instead of the unhelpful `display` field from history
- Redesign SKILL.md session resolution into 4 modes:
  - **Mode A** ("this") — auto-selects most recent session, no picker
  - **Mode B** (UUID) — direct lookup, unchanged
  - **Mode C** (named) — finds sessions renamed with `/rename` via `--mode name`
  - **Mode D** (picker) — fallback when args are empty or Mode A/C found nothing
- `list_sessions` now includes `project` field and supports `exclude_session`
- 18 new tests (34 total), all passing

## Test plan
- [x] All 34 tests passing
- [x] `/skillify this` auto-selects most recent session
- [x] `/skillify sprint-status-skill` finds session by custom title
- [x] `/skillify` with no args shows interactive picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)