### PR TITLE
docs: add LICENSE, CONTRIBUTING, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: Report something that isn't working correctly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Tell us what you see.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Run `/skillify ...`
+        2. Select ...
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 15.1 / Ubuntu 24.04 / etc."
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any error messages or logs.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: Suggest an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## What does this PR do?
+
+<!-- A brief description of the change. -->
+
+## How was this tested?
+
+<!-- How did you verify the change works? -->
+
+- [ ] `pytest` passes
+- [ ] `ruff check` passes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Skillify
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Development Setup
+
+```bash
+git clone https://github.com/nickommen/skillify.git
+cd skillify
+uv venv .venv && source .venv/bin/activate
+uv sync
+```
+
+## Running Tests
+
+```bash
+uv run pytest --cov
+```
+
+## Linting
+
+```bash
+uv run ruff check scripts/ tests/
+```
+
+## Submitting Changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your changes — add tests for new functionality.
+3. Ensure `pytest` and `ruff check` pass.
+4. Use [conventional commit](https://www.conventionalcommits.org/) format for your PR title (e.g. `feat: add X`, `fix: resolve Y`).
+5. Open a pull request against `main`.
+
+## Code Style
+
+- Python 3.12+, stdlib-only for runtime code (dev dependencies like pytest/ruff are fine).
+- Follow existing patterns in the codebase.
+- Ruff handles formatting and linting — run it before submitting.
+
+## Reporting Issues
+
+Open an issue on GitHub. Include:
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+- Your Python version and OS
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nick Ommen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file (was declared in pyproject.toml but missing)
- Add CONTRIBUTING.md with dev setup, testing, and PR guidelines
- Add GitHub issue templates (bug report + feature request) and PR template

Prepares the repo for going public. CODE_OF_CONDUCT.md should be added separately via GitHub's built-in Contributor Covenant template.

## Test plan
- [x] Verify LICENSE renders correctly on GitHub
- [x] Verify issue templates appear when creating a new issue
- [ ] Verify PR template populates when opening a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)