### PR TITLE
refactor: simplify session selection to two cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Also triggers on natural language: "turn this into a skill", "make this a skill"
 
 ## How It Works
 
-1. **Identify** the source conversation — current session, explicit session ID, or interactive picker from recent history
+1. **Identify** the source conversation — current project session or explicit session UUID
 2. **Parse** the conversation JSONL into a compact workflow manifest using `parse_conversation.py`
 3. **Supplement** with git state and project type detection for additional context
 4. **Interview** the user to confirm skill name, description, save location, tool mode, and workflow steps. For non-trivial workflows, also captures preconditions, idempotency, and escalation rules.

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Convert a Claude Code conversation into a deterministic Python-scripted skill.
 user-invocable: true
 context: fork
-argument-hint: [session-id | "this"]
+argument-hint: [session-uuid | "this"]
 allowed-tools:
   - Bash
   - Read
@@ -34,42 +34,16 @@ Convert a Claude Code conversation — where the user iterated on automating a t
 
 ### Step 1: Identify the Conversation
 
-Resolve the source conversation JSONL file. Check these modes **in order** — use the FIRST one that matches and do NOT fall through to later modes.
-
-**Mode A — "this" (auto-select most recent session):**
-If `$ARGUMENTS` contains "this", "current", or "this conversation": auto-select the most recent session for the current project directory. Do NOT show a picker.
+Resolve the source conversation JSONL file:
 
 ```
-python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode recent --project-dir "$PWD"
+python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode resolve --arguments "$ARGUMENTS" --project-dir "$PWD"
 ```
-Parse the JSON output for the `path` field. If not found (exit code 1), fall through to Mode D (interactive picker).
 
-**Mode B — Explicit session ID:**
-Only if `$ARGUMENTS` contains a UUID (pattern: `[0-9a-f-]{36}`):
-```
-python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode uuid --session-id "$ARGUMENTS"
-```
-Parse the JSON output for the `path` field. If not found (exit code 1), tell the user and ask for a different session ID.
+Parse the JSON output and handle based on the key present:
 
-**Mode C — Named session (from /rename):**
-Only if `$ARGUMENTS` contains text that is NOT empty, NOT "this"/"current", and NOT a UUID:
-```
-python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode name --session-name "$ARGUMENTS"
-```
-Parse the JSON output for the `path` field. If not found (exit code 1), fall through to Mode D (interactive picker).
-
-**Mode D — Interactive picker:**
-If `$ARGUMENTS` is empty, blank, or unset — OR if Mode A/C fell through because no session was found:
-1. List recent sessions:
-   ```
-   python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode list
-   ```
-   Parse the JSON array output — each entry has `session_id`, `timestamp`, `display`, and `project` fields.
-2. Present the list via AskUserQuestion. Format each option as `{timestamp} [{project}] {display}` so the user can identify sessions by time, project directory, and description.
-3. Locate the selected session's JSONL file:
-   ```
-   python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode uuid --session-id "{SELECTED_SESSION_ID}"
-   ```
+- **`"path"` key** — session resolved. Use the path value as the JSONL file. Continue to Step 2.
+- **`"error"` key** — show the error message to the user. The message includes guidance on how to list available sessions and re-run with a UUID.
 
 **Success criteria:** A valid JSONL file path is identified.
 

--- a/scripts/find_session.py
+++ b/scripts/find_session.py
@@ -1,70 +1,37 @@
 #!/usr/bin/env python3
 """Resolve a Claude Code conversation JSONL file.
 
-Modes:
-  parent    Find the parent session (most recent in history, excluding current fork).
-  recent    Find the most recent JSONL for a project directory.
-  uuid      Find a JSONL by session UUID.
-  name      Find a session by custom title or agent name (from /rename).
-  list      List the 10 most recent unique sessions.
-
 Usage:
-  python3 find_session.py --mode parent --exclude-session <fork-session-id>
-  python3 find_session.py --mode recent --project-dir /path/to/project
-  python3 find_session.py --mode uuid --session-id <uuid>
-  python3 find_session.py --mode name --session-name <name>
-  python3 find_session.py --mode list
+  python3 find_session.py --mode resolve --project-dir /path/to/project
+  python3 find_session.py --mode resolve --arguments "<uuid>" --project-dir /path/to/project
 
 Output (JSON to stdout):
-  recent/uuid/name: {"path": "/absolute/path/to/session.jsonl"}
-  list:             [{"session_id": "...", "timestamp": "...",
-                      "display": "...", "project": "..."}, ...]
+  {"path": "/absolute/path/to/session.jsonl"}   — session resolved
+  {"error": "..."}                              — resolution failed, message includes guidance
 """
 
 import argparse
 import json
 import os
+import re
 import sys
-from datetime import datetime
 from pathlib import Path
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
-HISTORY_FILE = Path.home() / ".claude" / "history.jsonl"
+
+UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
 
 
-def find_parent(exclude_session):
-    if not HISTORY_FILE.exists():
-        return None
-    with open(HISTORY_FILE) as f:
-        lines = f.readlines()
-    seen = set()
-    for line in reversed(lines):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            d = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        sid = d.get("sessionId", "")
-        if not sid or sid in seen or sid == exclude_session:
-            continue
-        path = find_by_uuid(sid)
-        if path:
-            return path
-        seen.add(sid)
-    return None
-
-
-def find_recent(project_dir, exclude_session=None):
+def find_recent(project_dir):
     slug = project_dir.replace("/", "-")
     project_path = CLAUDE_PROJECTS_DIR / slug
     if not project_path.is_dir():
         return None
     jsonl_files = sorted(project_path.glob("*.jsonl"), key=os.path.getmtime, reverse=True)
     for f in jsonl_files:
-        if exclude_session and f.stem == exclude_session:
-            continue
         return str(f)
     return None
 
@@ -77,177 +44,58 @@ def find_by_uuid(session_id):
     return None
 
 
-def get_first_user_message(session_id):
-    path = find_by_uuid(session_id)
-    if not path:
-        return None
-    try:
-        with open(path) as f:
-            for raw_line in f:
-                raw_line = raw_line.strip()
-                if not raw_line:
-                    continue
-                try:
-                    entry = json.loads(raw_line)
-                except json.JSONDecodeError:
-                    continue
-                if entry.get("type") != "user":
-                    continue
-                msg = entry.get("message", {})
-                content = msg.get("content", "")
-                if isinstance(content, str):
-                    text = content
-                elif isinstance(content, list):
-                    text = " ".join(
-                        b.get("text", "")
-                        for b in content
-                        if isinstance(b, dict) and b.get("type") == "text"
-                    )
-                else:
-                    continue
-                text = text.strip()
-                if text and not text.startswith("<"):
-                    return text[:120]
-    except OSError:
-        pass
-    return None
+def resolve(arguments, project_dir=None):
+    args_stripped = (arguments or "").strip()
+    args_lower = args_stripped.lower()
 
+    if not args_stripped or args_lower in ("this", "current", "this conversation"):
+        if project_dir:
+            path = find_recent(project_dir)
+            if path:
+                return {"path": path}
+        slug = project_dir.replace("/", "-") if project_dir else "<project-slug>"
+        return {
+            "error": (
+                f"No session found for this project directory.\n"
+                f"List available sessions with: ls ~/.claude/projects/{slug}/\n"
+                f"Then re-run: /skillify <session-uuid>"
+            ),
+        }
 
-def find_by_name(name):
-    name_lower = name.lower().strip()
-    if not CLAUDE_PROJECTS_DIR.is_dir():
-        return None
-    for dirpath, _, filenames in os.walk(CLAUDE_PROJECTS_DIR):
-        for fname in filenames:
-            if not fname.endswith(".jsonl"):
-                continue
-            path = os.path.join(dirpath, fname)
-            try:
-                with open(path) as f:
-                    for raw_line in f:
-                        raw_line = raw_line.strip()
-                        if not raw_line:
-                            continue
-                        try:
-                            entry = json.loads(raw_line)
-                        except json.JSONDecodeError:
-                            continue
-                        entry_type = entry.get("type", "")
-                        if entry_type == "custom-title":
-                            title = entry.get("customTitle", "")
-                            if title.lower().strip() == name_lower:
-                                return path
-                        elif entry_type == "agent-name":
-                            agent = entry.get("agentName", "")
-                            if agent.lower().strip() == name_lower:
-                                return path
-            except OSError:
-                continue
-    return None
+    if UUID_RE.fullmatch(args_stripped):
+        path = find_by_uuid(args_stripped)
+        if path:
+            return {"path": path}
+        return {
+            "error": (
+                f"Session not found: {args_stripped}\n"
+                f"List available sessions with: ls ~/.claude/projects/\n"
+                f"Then re-run: /skillify <session-uuid>"
+            ),
+        }
 
-
-def list_sessions(count=10, exclude_session=None):
-    if not HISTORY_FILE.exists():
-        print("History file not found: " + str(HISTORY_FILE), file=sys.stderr)
-        return []
-    sessions = []
-    seen = set()
-    with open(HISTORY_FILE) as f:
-        lines = f.readlines()
-    for line in reversed(lines):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            d = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        sid = d.get("sessionId", "")
-        if not sid or sid in seen or sid == exclude_session:
-            continue
-        seen.add(sid)
-        ts = d.get("timestamp", 0)
-        dt = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d %H:%M")
-        first_msg = get_first_user_message(sid)
-        display = first_msg if first_msg else d.get("display", "")[:80]
-        project = d.get("project", "")
-        sessions.append({
-            "session_id": sid,
-            "timestamp": dt,
-            "display": display,
-            "project": project,
-        })
-        if len(sessions) >= count:
-            break
-    return sessions
+    return {
+        "error": (
+            f"Unrecognized argument: {args_stripped}\n"
+            f"Usage: /skillify          — skillify the current project session\n"
+            f"       /skillify this     — same as above\n"
+            f"       /skillify <uuid>   — skillify a specific session"
+        ),
+    }
 
 
 def main():
     parser = argparse.ArgumentParser(description="Resolve Claude Code conversation JSONL files")
-    modes = ["parent", "recent", "uuid", "name", "list"]
-    parser.add_argument("--mode", required=True, choices=modes)
-    parser.add_argument("--project-dir", help="Project directory (for recent mode)")
-    parser.add_argument("--session-id", help="Session UUID (for uuid mode)")
-    parser.add_argument("--session-name", help="Session name (for name mode)")
-    parser.add_argument(
-        "--exclude-session",
-        help="Session ID to skip (for parent/recent mode)",
-    )
+    parser.add_argument("--mode", required=True, choices=["resolve"])
+    parser.add_argument("--arguments", help="Raw arguments string", default="")
+    parser.add_argument("--project-dir", help="Project directory")
     args = parser.parse_args()
 
-    if args.mode == "parent":
-        if not args.exclude_session:
-            print("--exclude-session required for parent mode", file=sys.stderr)
-            sys.exit(1)
-        path = find_parent(args.exclude_session)
-        if path:
-            json.dump({"path": path}, sys.stdout)
-        else:
-            print("No parent session found", file=sys.stderr)
-            sys.exit(1)
-
-    elif args.mode == "recent":
-        if not args.project_dir:
-            print("--project-dir required for recent mode", file=sys.stderr)
-            sys.exit(1)
-        path = find_recent(args.project_dir, exclude_session=args.exclude_session)
-        if path:
-            json.dump({"path": path}, sys.stdout)
-        else:
-            print("No JSONL files found for project: " + args.project_dir, file=sys.stderr)
-            sys.exit(1)
-
-    elif args.mode == "uuid":
-        if not args.session_id:
-            print("--session-id required for uuid mode", file=sys.stderr)
-            sys.exit(1)
-        path = find_by_uuid(args.session_id)
-        if path:
-            json.dump({"path": path}, sys.stdout)
-        else:
-            print("Session not found: " + args.session_id, file=sys.stderr)
-            sys.exit(1)
-
-    elif args.mode == "name":
-        if not args.session_name:
-            print("--session-name required for name mode", file=sys.stderr)
-            sys.exit(1)
-        path = find_by_name(args.session_name)
-        if path:
-            json.dump({"path": path}, sys.stdout)
-        else:
-            print("Session not found with name: " + args.session_name, file=sys.stderr)
-            sys.exit(1)
-
-    elif args.mode == "list":
-        sessions = list_sessions(exclude_session=args.exclude_session)
-        if sessions:
-            json.dump(sessions, sys.stdout, indent=2)
-        else:
-            print("No sessions found", file=sys.stderr)
-            sys.exit(1)
-
+    result = resolve(args.arguments, project_dir=args.project_dir)
+    json.dump(result, sys.stdout)
     print("", file=sys.stdout)
+    if "error" in result:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -1,15 +1,11 @@
 """Tests for find_session.py."""
 
-import json
 import os
 
 from scripts.find_session import (
-    find_by_name,
     find_by_uuid,
-    find_parent,
     find_recent,
-    get_first_user_message,
-    list_sessions,
+    resolve,
 )
 
 
@@ -23,7 +19,6 @@ class TestFindRecent:
         old.write_text("{}")
         new = project_dir / "new-session.jsonl"
         new.write_text("{}")
-        # Ensure new has a later mtime
         os.utime(old, (1000, 1000))
         os.utime(new, (2000, 2000))
 
@@ -54,33 +49,6 @@ class TestFindRecent:
         result = find_recent("/home/user/project")
         assert result is not None
 
-    def test_exclude_session_skips_most_recent(self, tmp_path, monkeypatch):
-        slug = "-home-user-myproject"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-
-        old = project_dir / "source-session.jsonl"
-        old.write_text("{}")
-        fork = project_dir / "fork-session.jsonl"
-        fork.write_text("{}")
-        os.utime(old, (1000, 1000))
-        os.utime(fork, (2000, 2000))
-
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_recent("/home/user/myproject", exclude_session="fork-session")
-        assert result == str(old)
-
-    def test_exclude_session_returns_none_if_only_match(self, tmp_path, monkeypatch):
-        slug = "-home-user-myproject"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-
-        only = project_dir / "only-session.jsonl"
-        only.write_text("{}")
-
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_recent("/home/user/myproject", exclude_session="only-session") is None
-
     def test_ignores_non_jsonl_files(self, tmp_path, monkeypatch):
         slug = "-home-user-proj"
         project_dir = tmp_path / "projects" / slug
@@ -89,110 +57,6 @@ class TestFindRecent:
 
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
         assert find_recent("/home/user/proj") is None
-
-
-class TestFindParent:
-    def _write_history(self, history_file, entries):
-        with open(history_file, "w") as f:
-            for entry in entries:
-                f.write(json.dumps(entry) + "\n")
-
-    def test_finds_parent_session(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "parent-id", "timestamp": 1700000000000, "display": "Parent"},
-            {"sessionId": "fork-id", "timestamp": 1700001000000, "display": "Fork"},
-        ])
-        project_dir = tmp_path / "projects" / "some-project"
-        project_dir.mkdir(parents=True)
-        (project_dir / "parent-id.jsonl").write_text("{}")
-        (project_dir / "fork-id.jsonl").write_text("{}")
-
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_parent("fork-id")
-        assert result.endswith("parent-id.jsonl")
-
-    def test_skips_fork_session(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "fork-id", "timestamp": 1700001000000, "display": "Fork"},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_parent("fork-id") is None
-
-    def test_returns_none_for_missing_history(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", tmp_path / "nonexistent.jsonl")
-        assert find_parent("fork-id") is None
-
-    def test_skips_sessions_without_jsonl(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "no-file", "timestamp": 1700001000000, "display": "No file"},
-            {"sessionId": "has-file", "timestamp": 1700000000000, "display": "Has file"},
-        ])
-        project_dir = tmp_path / "projects" / "some-project"
-        project_dir.mkdir(parents=True)
-        (project_dir / "has-file.jsonl").write_text("{}")
-
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_parent("fork-id")
-        assert result.endswith("has-file.jsonl")
-
-
-class TestGetFirstUserMessage:
-    def _write_session(self, path, entries):
-        with open(path, "w") as f:
-            for entry in entries:
-                f.write(json.dumps(entry) + "\n")
-
-    def test_extracts_first_user_message(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
-        project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-1.jsonl", [
-            {"type": "system", "content": "system msg"},
-            {"type": "user", "message": {"role": "human", "content": "Hello world"}},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert get_first_user_message("sess-1") == "Hello world"
-
-    def test_skips_xml_tagged_messages(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
-        project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-2.jsonl", [
-            {"type": "user", "message": {"role": "human",
-                "content": "<ide_opened_file>foo</ide_opened_file>"}},
-            {"type": "user", "message": {"role": "human", "content": "Real question here"}},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert get_first_user_message("sess-2") == "Real question here"
-
-    def test_returns_none_for_missing_session(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert get_first_user_message("nonexistent") is None
-
-    def test_truncates_long_messages(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
-        project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-3.jsonl", [
-            {"type": "user", "message": {"role": "human", "content": "x" * 200}},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert len(get_first_user_message("sess-3")) == 120
-
-    def test_handles_list_content(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
-        project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-4.jsonl", [
-            {"type": "user", "message": {"role": "human", "content": [
-                {"type": "text", "text": "Part one"},
-                {"type": "text", "text": "part two"},
-            ]}},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert get_first_user_message("sess-4") == "Part one part two"
 
 
 class TestFindByUuid:
@@ -222,173 +86,78 @@ class TestFindByUuid:
         assert result == str(target)
 
 
-class TestFindByName:
-    def _write_session(self, path, entries):
-        with open(path, "w") as f:
-            for entry in entries:
-                f.write(json.dumps(entry) + "\n")
-
-    def test_finds_by_custom_title(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
+class TestResolve:
+    def test_empty_args_returns_path(self, tmp_path, monkeypatch):
+        slug = "-home-user-myproject"
+        project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-1.jsonl", [
-            {"type": "user", "message": {"role": "human", "content": "hello"}},
-            {"type": "custom-title", "customTitle": "sprint-status-skill"},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_by_name("sprint-status-skill")
-        assert result.endswith("sess-1.jsonl")
+        session = project_dir / "session.jsonl"
+        session.write_text("{}")
 
-    def test_finds_by_agent_name(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("", project_dir="/home/user/myproject")
+        assert result == {"path": str(session)}
+
+    def test_this_returns_path(self, tmp_path, monkeypatch):
+        slug = "-home-user-myproject"
+        project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-2.jsonl", [
-            {"type": "agent-name", "agentName": "weekly-rollup"},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_by_name("weekly-rollup")
-        assert result.endswith("sess-2.jsonl")
+        session = project_dir / "session.jsonl"
+        session.write_text("{}")
 
-    def test_case_insensitive(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("this", project_dir="/home/user/myproject")
+        assert result == {"path": str(session)}
+
+    def test_current_returns_path(self, tmp_path, monkeypatch):
+        slug = "-home-user-myproject"
+        project_dir = tmp_path / "projects" / slug
         project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-3.jsonl", [
-            {"type": "custom-title", "customTitle": "Sprint-Status-Skill"},
-        ])
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_by_name("sprint-status-skill") is not None
+        session = project_dir / "session.jsonl"
+        session.write_text("{}")
 
-    def test_returns_none_for_no_match(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("current", project_dir="/home/user/myproject")
+        assert result == {"path": str(session)}
+
+    def test_uuid_returns_path(self, tmp_path, monkeypatch):
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        project_dir = tmp_path / "projects" / "some-project"
         project_dir.mkdir(parents=True)
-        self._write_session(project_dir / "sess-4.jsonl", [
-            {"type": "custom-title", "customTitle": "other-skill"},
-        ])
+        session = project_dir / f"{uuid}.jsonl"
+        session.write_text("{}")
+
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_by_name("sprint-status-skill") is None
+        result = resolve(uuid)
+        assert result == {"path": str(session)}
 
-    def test_returns_none_for_empty_projects_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "nonexistent")
-        assert find_by_name("anything") is None
-
-    def test_skips_non_jsonl_files(self, tmp_path, monkeypatch):
-        project_dir = tmp_path / "projects" / "test"
-        project_dir.mkdir(parents=True)
-        (project_dir / "notes.txt").write_text('{"type":"custom-title","customTitle":"match"}')
+    def test_uuid_not_found_returns_error(self, tmp_path, monkeypatch):
+        (tmp_path / "projects").mkdir(parents=True)
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_by_name("match") is None
 
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        result = resolve(uuid)
+        assert "error" in result
+        assert uuid in result["error"]
 
-class TestListSessions:
-    def _write_history(self, history_file, entries):
-        with open(history_file, "w") as f:
-            for entry in entries:
-                f.write(json.dumps(entry) + "\n")
+    def test_this_no_session_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("this", project_dir="/nonexistent/project")
+        assert "error" in result
+        assert "/skillify" in result["error"]
 
-    def test_lists_recent_sessions(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "aaa", "timestamp": 1700000000000, "display": "First session"},
-            {"sessionId": "bbb", "timestamp": 1700001000000, "display": "Second session"},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
+    def test_this_no_project_dir_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("this")
+        assert "error" in result
 
-        sessions = list_sessions()
-        assert len(sessions) == 2
-        assert sessions[0]["session_id"] == "bbb"
-        assert sessions[1]["session_id"] == "aaa"
+    def test_unrecognized_argument_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("some-random-text")
+        assert "error" in result
+        assert "Unrecognized argument" in result["error"]
 
-    def test_excludes_session(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "aaa", "timestamp": 1700000000000, "display": "First"},
-            {"sessionId": "fork", "timestamp": 1700001000000, "display": "Fork"},
-            {"sessionId": "bbb", "timestamp": 1700002000000, "display": "Second"},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions(exclude_session="fork")
-        assert len(sessions) == 2
-        ids = [s["session_id"] for s in sessions]
-        assert "fork" not in ids
-
-    def test_deduplicates_sessions(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "aaa", "timestamp": 1700000000000, "display": "First"},
-            {"sessionId": "aaa", "timestamp": 1700001000000, "display": "First again"},
-            {"sessionId": "bbb", "timestamp": 1700002000000, "display": "Second"},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions()
-        assert len(sessions) == 2
-        ids = [s["session_id"] for s in sessions]
-        assert ids.count("aaa") == 1
-
-    def test_limits_to_count(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        entries = [
-            {"sessionId": f"session-{i}", "timestamp": 1700000000000 + i * 1000, "display": f"S{i}"}
-            for i in range(20)
-        ]
-        self._write_history(history, entries)
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions(count=5)
-        assert len(sessions) == 5
-
-    def test_returns_empty_for_missing_history(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", tmp_path / "nonexistent.jsonl")
-        assert list_sessions() == []
-
-    def test_skips_entries_without_session_id(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"timestamp": 1700000000000, "display": "No session ID"},
-            {"sessionId": "", "timestamp": 1700001000000, "display": "Empty session ID"},
-            {"sessionId": "valid", "timestamp": 1700002000000, "display": "Valid"},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions()
-        assert len(sessions) == 1
-        assert sessions[0]["session_id"] == "valid"
-
-    def test_truncates_display_to_80_chars(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        long_display = "x" * 200
-        self._write_history(history, [
-            {"sessionId": "aaa", "timestamp": 1700000000000, "display": long_display},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions()
-        assert len(sessions[0]["display"]) == 80
-
-    def test_handles_malformed_json_lines(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        with open(history, "w") as f:
-            f.write("not valid json\n")
-            entry = {"sessionId": "ok", "timestamp": 1700000000000, "display": "Good"}
-            f.write(json.dumps(entry) + "\n")
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions()
-        assert len(sessions) == 1
-        assert sessions[0]["session_id"] == "ok"
-
-    def test_formats_timestamp(self, tmp_path, monkeypatch):
-        history = tmp_path / "history.jsonl"
-        self._write_history(history, [
-            {"sessionId": "aaa", "timestamp": 1700000000000, "display": "Test"},
-        ])
-        monkeypatch.setattr("scripts.find_session.HISTORY_FILE", history)
-
-        sessions = list_sessions()
-        assert sessions[0]["timestamp"]
-        # Should be in YYYY-MM-DD HH:MM format
-        parts = sessions[0]["timestamp"].split(" ")
-        assert len(parts) == 2
-        assert "-" in parts[0]
-        assert ":" in parts[1]
+    def test_empty_no_project_dir_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+        result = resolve("")
+        assert "error" in result


### PR DESCRIPTION
## Summary

- Reduce `find_session.py` from 5 modes / 6 functions (255 lines) to a single `resolve()` entry point (97 lines) supporting two cases: auto-detect from project directory or explicit UUID
- Remove unused `find_parent`, `find_by_name`, `list_sessions`, `get_first_user_message`, and interactive picker
- Simplify SKILL.md Step 1 from a 4-mode cascade to a single `--mode resolve` call
- Update README to reflect simplified session selection

## Test plan

- [x] All 166 tests pass (`uv run pytest -v`)
- [x] `TestResolve` class covers: empty args, "this", "current", UUID found, UUID not found, missing project dir, unrecognized argument
- [x] Manual: run `/skillify this` in a project with a session
- [x] Manual: run `/skillify <uuid>` with a known session UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)