### PR TITLE
refactor: use PID-based session detection instead of mtime heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,14 @@ After installation, `/skillify` will be available in Claude Code.
 
 ```bash
 # Skillify the current conversation
+/skillify
 /skillify this
 
 # Skillify a specific past conversation by session ID
 /skillify 15555f6f-ed1d-47fb-b542-efdaff259864
-
-# Browse recent conversations and pick one
-/skillify
 ```
 
 Also triggers on natural language: "turn this into a skill", "make this a skill", "create a skill from this conversation", "convert this to a skill"
-
-## Tips
-
-**Start in a dedicated project directory.** When exploring the task you want to
-skillify, do that work in a new directory — ideally the one that will become the
-skill's repo. This avoids conflicting Claude Code sessions in your main project
-and makes session selection straightforward when you run `/skillify`.
 
 ## How It Works
 
@@ -106,7 +97,7 @@ skillify/
   scripts/
     parse_conversation.py           # JSONL conversation parser
     parse_agent_output.py           # Agent output file extractor
-    find_session.py                 # Session JSONL resolution (recent/uuid/list)
+    find_session.py                 # Session JSONL resolution (pid/uuid)
     validate_skill.py               # Generated skill validation (syntax, frontmatter)
   prompts/
     generate_skill.md               # Generation agent prompt template

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ Convert a Claude Code conversation — where the user iterated on automating a t
 Resolve the source conversation JSONL file:
 
 ```
-python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode resolve --arguments "$ARGUMENTS" --project-dir "$PWD"
+python3 ${CLAUDE_SKILL_DIR}/scripts/find_session.py --mode resolve --arguments "$ARGUMENTS"
 ```
 
 Parse the JSON output and handle based on the key present:

--- a/scripts/find_session.py
+++ b/scripts/find_session.py
@@ -2,8 +2,8 @@
 """Resolve a Claude Code conversation JSONL file.
 
 Usage:
-  python3 find_session.py --mode resolve --project-dir /path/to/project
-  python3 find_session.py --mode resolve --arguments "<uuid>" --project-dir /path/to/project
+  python3 find_session.py --mode resolve
+  python3 find_session.py --mode resolve --arguments "<uuid>"
 
 Output (JSON to stdout):
   {"path": "/absolute/path/to/session.jsonl"}   — session resolved
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+CLAUDE_SESSIONS_DIR = Path.home() / ".claude" / "sessions"
 
 UUID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
@@ -25,14 +26,41 @@ UUID_RE = re.compile(
 )
 
 
-def find_recent(project_dir):
-    slug = project_dir.replace("/", "-")
-    project_path = CLAUDE_PROJECTS_DIR / slug
-    if not project_path.is_dir():
+def get_ancestor_pids():
+    """Yield PIDs walking up the process tree from this process."""
+    pid = os.getpid()
+    while pid and pid != 1:
+        yield pid
+        try:
+            with open(f"/proc/{pid}/stat") as f:
+                fields = f.read().split()
+                pid = int(fields[3])
+        except (OSError, IndexError, ValueError):
+            break
+
+
+def find_by_pid():
+    """Find the current session JSONL by walking up the process tree.
+
+    Looks for a matching {pid}.json in ~/.claude/sessions/, extracts the
+    sessionId, then locates the corresponding JSONL via find_by_uuid().
+    """
+    if not CLAUDE_SESSIONS_DIR.is_dir():
         return None
-    jsonl_files = sorted(project_path.glob("*.jsonl"), key=os.path.getmtime, reverse=True)
-    for f in jsonl_files:
-        return str(f)
+
+    session_files = {f.stem: f for f in CLAUDE_SESSIONS_DIR.glob("*.json")}
+    if not session_files:
+        return None
+
+    for pid in get_ancestor_pids():
+        session_file = session_files.get(str(pid))
+        if session_file:
+            try:
+                data = json.loads(session_file.read_text())
+                return find_by_uuid(data["sessionId"])
+            except (json.JSONDecodeError, KeyError, OSError):
+                return None
+
     return None
 
 
@@ -44,22 +72,16 @@ def find_by_uuid(session_id):
     return None
 
 
-def resolve(arguments, project_dir=None):
+def resolve(arguments):
     args_stripped = (arguments or "").strip()
     args_lower = args_stripped.lower()
 
     if not args_stripped or args_lower in ("this", "current", "this conversation"):
-        if project_dir:
-            path = find_recent(project_dir)
-            if path:
-                return {"path": path}
-        slug = project_dir.replace("/", "-") if project_dir else "<project-slug>"
+        path = find_by_pid()
+        if path:
+            return {"path": path}
         return {
-            "error": (
-                f"No session found for this project directory.\n"
-                f"List available sessions with: ls ~/.claude/projects/{slug}/\n"
-                f"Then re-run: /skillify <session-uuid>"
-            ),
+            "error": "Could not detect session. Use: /skillify <uuid>",
         }
 
     if UUID_RE.fullmatch(args_stripped):
@@ -88,10 +110,9 @@ def main():
     parser = argparse.ArgumentParser(description="Resolve Claude Code conversation JSONL files")
     parser.add_argument("--mode", required=True, choices=["resolve"])
     parser.add_argument("--arguments", help="Raw arguments string", default="")
-    parser.add_argument("--project-dir", help="Project directory")
     args = parser.parse_args()
 
-    result = resolve(args.arguments, project_dir=args.project_dir)
+    result = resolve(args.arguments)
     json.dump(result, sys.stdout)
     print("", file=sys.stdout)
     if "error" in result:

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -1,62 +1,108 @@
 """Tests for find_session.py."""
 
+import json
 import os
 
 from scripts.find_session import (
+    find_by_pid,
     find_by_uuid,
-    find_recent,
+    get_ancestor_pids,
     resolve,
 )
 
 
-class TestFindRecent:
-    def test_finds_most_recent_jsonl(self, tmp_path, monkeypatch):
-        slug = "-home-user-myproject"
-        project_dir = tmp_path / "projects" / slug
+class TestGetAncestorPids:
+    def test_yields_current_pid(self):
+        pids = list(get_ancestor_pids())
+        assert pids[0] == os.getpid()
+
+    def test_yields_at_least_two_pids(self):
+        pids = list(get_ancestor_pids())
+        assert len(pids) >= 2
+
+    def test_does_not_include_pid_1(self):
+        pids = list(get_ancestor_pids())
+        assert 1 not in pids
+
+
+class TestFindByPid:
+    def _setup_session(self, tmp_path, pid, session_id, monkeypatch):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(exist_ok=True)
+        (sessions_dir / f"{pid}.json").write_text(
+            json.dumps({"pid": pid, "sessionId": session_id})
+        )
+        monkeypatch.setattr("scripts.find_session.CLAUDE_SESSIONS_DIR", sessions_dir)
+        return sessions_dir
+
+    def test_finds_session_via_pid(self, tmp_path, monkeypatch):
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        self._setup_session(tmp_path, 1234, uuid, monkeypatch)
+
+        project_dir = tmp_path / "projects" / "some-project"
         project_dir.mkdir(parents=True)
-
-        old = project_dir / "old-session.jsonl"
-        old.write_text("{}")
-        new = project_dir / "new-session.jsonl"
-        new.write_text("{}")
-        os.utime(old, (1000, 1000))
-        os.utime(new, (2000, 2000))
+        jsonl = project_dir / f"{uuid}.jsonl"
+        jsonl.write_text("{}")
 
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_recent("/home/user/myproject")
-        assert result == str(new)
+        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([9999, 1234]))
 
-    def test_returns_none_for_missing_project(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_recent("/nonexistent/project") is None
+        assert find_by_pid() == str(jsonl)
 
-    def test_returns_none_for_empty_project_dir(self, tmp_path, monkeypatch):
-        slug = "-home-user-emptyproject"
-        project_dir = tmp_path / "projects" / slug
+    def test_skips_non_matching_pids(self, tmp_path, monkeypatch):
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        self._setup_session(tmp_path, 3000, uuid, monkeypatch)
+
+        project_dir = tmp_path / "projects" / "proj"
         project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{uuid}.jsonl"
+        jsonl.write_text("{}")
 
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_recent("/home/user/emptyproject") is None
+        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([1000, 2000, 3000]))
 
-    def test_converts_path_to_slug(self, tmp_path, monkeypatch):
-        slug = "-home-user-project"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-        f = project_dir / "abc.jsonl"
-        f.write_text("{}")
+        assert find_by_pid() == str(jsonl)
 
+    def test_returns_none_when_no_sessions_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.CLAUDE_SESSIONS_DIR", tmp_path / "nonexistent")
+        assert find_by_pid() is None
+
+    def test_returns_none_when_sessions_dir_empty(self, tmp_path, monkeypatch):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr("scripts.find_session.CLAUDE_SESSIONS_DIR", sessions_dir)
+        assert find_by_pid() is None
+
+    def test_returns_none_when_no_pid_matches(self, tmp_path, monkeypatch):
+        self._setup_session(tmp_path, 5555, "some-uuid", monkeypatch)
+        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([1111, 2222]))
+        assert find_by_pid() is None
+
+    def test_returns_none_on_corrupt_session_file(self, tmp_path, monkeypatch):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "1234.json").write_text("not json")
+        monkeypatch.setattr("scripts.find_session.CLAUDE_SESSIONS_DIR", sessions_dir)
+        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([1234]))
+        assert find_by_pid() is None
+
+    def test_returns_none_on_missing_session_id_key(self, tmp_path, monkeypatch):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "1234.json").write_text(json.dumps({"pid": 1234}))
+        monkeypatch.setattr("scripts.find_session.CLAUDE_SESSIONS_DIR", sessions_dir)
+        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([1234]))
+        assert find_by_pid() is None
+
+    def test_returns_none_when_jsonl_not_found(self, tmp_path, monkeypatch):
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        self._setup_session(tmp_path, 1234, uuid, monkeypatch)
+
+        (tmp_path / "projects").mkdir()
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = find_recent("/home/user/project")
-        assert result is not None
+        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([1234]))
 
-    def test_ignores_non_jsonl_files(self, tmp_path, monkeypatch):
-        slug = "-home-user-proj"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-        (project_dir / "notes.txt").write_text("not a jsonl")
-
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        assert find_recent("/home/user/proj") is None
+        assert find_by_pid() is None
 
 
 class TestFindByUuid:
@@ -87,38 +133,39 @@ class TestFindByUuid:
 
 
 class TestResolve:
-    def test_empty_args_returns_path(self, tmp_path, monkeypatch):
-        slug = "-home-user-myproject"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-        session = project_dir / "session.jsonl"
-        session.write_text("{}")
+    def test_empty_args_uses_pid_detection(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.find_session.find_by_pid",
+            lambda: "/path/to/session.jsonl",
+        )
+        assert resolve("") == {"path": "/path/to/session.jsonl"}
 
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = resolve("", project_dir="/home/user/myproject")
-        assert result == {"path": str(session)}
+    def test_this_uses_pid_detection(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.find_session.find_by_pid",
+            lambda: "/path/to/session.jsonl",
+        )
+        assert resolve("this") == {"path": "/path/to/session.jsonl"}
 
-    def test_this_returns_path(self, tmp_path, monkeypatch):
-        slug = "-home-user-myproject"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-        session = project_dir / "session.jsonl"
-        session.write_text("{}")
+    def test_current_uses_pid_detection(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.find_session.find_by_pid",
+            lambda: "/path/to/session.jsonl",
+        )
+        assert resolve("current") == {"path": "/path/to/session.jsonl"}
 
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = resolve("this", project_dir="/home/user/myproject")
-        assert result == {"path": str(session)}
+    def test_this_conversation_uses_pid_detection(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.find_session.find_by_pid",
+            lambda: "/path/to/session.jsonl",
+        )
+        assert resolve("this conversation") == {"path": "/path/to/session.jsonl"}
 
-    def test_current_returns_path(self, tmp_path, monkeypatch):
-        slug = "-home-user-myproject"
-        project_dir = tmp_path / "projects" / slug
-        project_dir.mkdir(parents=True)
-        session = project_dir / "session.jsonl"
-        session.write_text("{}")
-
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = resolve("current", project_dir="/home/user/myproject")
-        assert result == {"path": str(session)}
+    def test_pid_detection_failure_returns_error(self, monkeypatch):
+        monkeypatch.setattr("scripts.find_session.find_by_pid", lambda: None)
+        result = resolve("")
+        assert "error" in result
+        assert "/skillify <uuid>" in result["error"]
 
     def test_uuid_returns_path(self, tmp_path, monkeypatch):
         uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -140,24 +187,8 @@ class TestResolve:
         assert "error" in result
         assert uuid in result["error"]
 
-    def test_this_no_session_returns_error(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = resolve("this", project_dir="/nonexistent/project")
-        assert "error" in result
-        assert "/skillify" in result["error"]
-
-    def test_this_no_project_dir_returns_error(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = resolve("this")
-        assert "error" in result
-
     def test_unrecognized_argument_returns_error(self, tmp_path, monkeypatch):
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
         result = resolve("some-random-text")
         assert "error" in result
         assert "Unrecognized argument" in result["error"]
-
-    def test_empty_no_project_dir_returns_error(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        result = resolve("")
-        assert "error" in result

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -59,7 +59,10 @@ class TestFindByPid:
         jsonl.write_text("{}")
 
         monkeypatch.setattr("scripts.find_session.CLAUDE_PROJECTS_DIR", tmp_path / "projects")
-        monkeypatch.setattr("scripts.find_session.get_ancestor_pids", lambda: iter([1000, 2000, 3000]))
+        monkeypatch.setattr(
+            "scripts.find_session.get_ancestor_pids",
+            lambda: iter([1000, 2000, 3000]),
+        )
 
         assert find_by_pid() == str(jsonl)
 


### PR DESCRIPTION
## Summary
- Replace `find_recent()` (most-recently-modified JSONL) with `find_by_pid()` which walks the process tree to find the exact Claude Code session
- Remove `--project-dir` CLI argument — no longer needed
- Simplify error message for failed session detection

## Test plan
- [x] `uv run pytest tests/test_find_session.py -v` — 22 tests pass
- [x] `uv run pytest` — full suite (161 tests) passes
- [x] Invoke `/skillify` from a Claude Code session and confirm it resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)