### PR TITLE
refactor: remove skillify.json config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,6 @@ Also triggers on natural language: "turn this into a skill", "make this a skill"
 8. **Validate** generated Python syntax and YAML frontmatter
 9. **Report** created files, tool dependencies, env vars needed, and how to invoke
 
-## Configuration
-
-Optionally create `~/.claude/skillify.json` to set defaults:
-
-```json
-{
-  "default_save_location": "~/skills",
-  "author": ""
-}
-```
-
-All fields are optional. Without a config file, skillify uses sensible defaults.
-
 ## Generated Skill Structure
 
 When skillify generates a new skill, it creates:

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,12 +69,7 @@ Read `/tmp/skillify-manifest.json` to get the full manifest.
 
 ---
 
-### Step 3: Load Config, Present Summary, and Interview
-
-Read the user's skillify config if it exists at `~/.claude/skillify.json`. If the file does not exist, use empty defaults.
-
-Use config values as defaults in the interview. If no config exists, use built-in defaults:
-- `default_save_location`: `~/skills`
+### Step 3: Present Summary and Interview
 
 Present the manifest summary to the user:
 - Total messages, tool calls, files written
@@ -90,7 +85,7 @@ Then conduct a MANDATORY interview via AskUserQuestion. Do NOT skip this step. D
 - Suggest a skill name based on the workflow. Let the user confirm or rename.
 - Suggest a one-line description (must include what it does AND when to use it). Let the user confirm or edit.
 - Ask where to save the skill. Do NOT save directly into `~/.claude/` — writes there trigger sensitive-file permission prompts.
-  - **Personal skills directory** (Recommended) — save to `{config.default_save_location}/{name}/`. A symlink to `~/.claude/skills/{name}` will be created in the final step for discovery.
+  - **Personal skills directory** (Recommended) — save to `~/skills/{name}/`. A symlink to `~/.claude/skills/{name}` will be created in the final step for discovery.
   - **This repo** (`.claude/skills/{name}/`) — for repo-specific workflows, discovered automatically (no symlink needed)
   - **Custom path** — let the user specify any directory via "Other" (e.g., a shared skills repo). A symlink will be created for discovery.
 - Ask about tool mode:


### PR DESCRIPTION
## Summary
- Remove `~/.claude/skillify.json` config loading from the interview step — users answer the same questions every run, so persistent defaults add no value
- Hardcode `~/skills` as the default save location instead of reading from config
- Remove the Configuration section from README.md

## Test plan
- No test changes needed — config was only referenced in docs/procedure, never implemented in Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)