### PR TITLE
refactor: use isolated temp directories for build intermediates

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -31,7 +31,7 @@ Convert a Claude Code conversation — where the user iterated on automating a t
 - Generated skills must list all tools they call in `allowed-tools`.
 - Generated skills preserve the same MCP tools and CLIs from the source conversation.
 - Keep Bash commands simple to avoid Claude Code security prompts. Specifically: no multi-line commands, no heredocs, no inline `python3 -c`, no `$(cmd)` in file paths or arguments (capture to a variable first), and no `#` characters in quoted strings. If complex logic is needed, write it to a temporary Python script and execute that.
-- Generated skills must never write files under `~/.claude/` or `${CLAUDE_SKILL_DIR}/`. Use `/tmp/{skill-name}/` for transient intermediate files. Write final output to the current working directory (`$PWD`).
+- Generated skills must never write files under `~/.claude/` or `${CLAUDE_SKILL_DIR}/`. For transient intermediate files, create an isolated workspace with `mktemp -d -t {skill-name}-XXXXXXXX` at the start of the procedure and clean it up with `rm -rf` in a final Cleanup step. Write final output to the current working directory (`$PWD`).
 - Follow the Procedure steps exactly in order. Do NOT skip steps. The save location MUST come from the Step 3 interview — never invent or guess a path.
 
 ## Procedure
@@ -55,15 +55,23 @@ Parse the JSON output and handle based on the key present:
 
 ### Step 2: Parse Conversation
 
+Create an isolated workspace directory for this run's intermediate files:
+
+```
+mktemp -d -t skillify-XXXXXXXX
+```
+
+Capture the output path — this is the `{WORKSPACE_DIR}` for all intermediate files in this run.
+
 Run the conversation parser to extract the workflow manifest:
 
 ```
-python3 ${CLAUDE_SKILL_DIR}/scripts/parse_conversation.py "{JSONL_PATH}" > /tmp/skillify-manifest.json
+python3 ${CLAUDE_SKILL_DIR}/scripts/parse_conversation.py "{JSONL_PATH}" > {WORKSPACE_DIR}/manifest.json
 ```
 
 If the parser fails, show the error and stop.
 
-Read `/tmp/skillify-manifest.json` to get the full manifest.
+Read `{WORKSPACE_DIR}/manifest.json` to get the full manifest.
 
 **Success criteria:** Manifest JSON is valid and contains at least 1 tool call.
 
@@ -134,12 +142,12 @@ Substitute the placeholders:
 
 Launch an Agent with the substituted prompt. The Agent will output file contents in clearly marked `## FILE:` sections.
 
-Save the Agent's output to a temporary file, then parse it deterministically:
+Save the Agent's output to `{WORKSPACE_DIR}/agent-output.txt`, then parse it deterministically:
 ```
-python3 ${CLAUDE_SKILL_DIR}/scripts/parse_agent_output.py /tmp/skillify-agent-output.txt > /tmp/skillify-files.json
+python3 ${CLAUDE_SKILL_DIR}/scripts/parse_agent_output.py {WORKSPACE_DIR}/agent-output.txt > {WORKSPACE_DIR}/files.json
 ```
 
-Read `/tmp/skillify-files.json` to get the list of files.
+Read `{WORKSPACE_DIR}/files.json` to get the list of files.
 
 **Success criteria:** Parser extracts at least SKILL.md and one Python script.
 
@@ -196,3 +204,13 @@ Tell the user:
 6. **Suggest a test run** — recommend invoking the skill once to verify it works end-to-end
 
 **Success criteria:** User has all information needed to use the new skill.
+
+---
+
+### Cleanup
+
+Remove the workspace directory used for intermediate files:
+
+```
+rm -rf {WORKSPACE_DIR}
+```

--- a/prompts/generate_skill.md
+++ b/prompts/generate_skill.md
@@ -113,9 +113,10 @@ Skip this file only for skills with no arguments and trivial output.
    - `allowed-tools`: list every tool the skill calls. Use prefix patterns like `Bash(gh *)` for CLI tools. Include `Skill(other-skill)` if composing with other skills.
    - `argument-hint`: show expected args in autocomplete (e.g., `"[issue-number]"`)
 3. **Minimal orchestration** — the procedure should be:
-   - Step 1: Run validators, create output directory, run the Python script, capturing output to a timestamped file
+   - Step 1: Create an isolated workspace directory with `mktemp -d -t {skill-name}-XXXXXXXX`, run validators, run the Python script, capturing output to a timestamped file
    - Step 2: Read and present the output
    - Step 3: Provide a brief summary with key metrics
+   - Cleanup: Remove the workspace directory with `rm -rf {WORKSPACE_DIR}`
 4. **Per-step success criteria** — each step must state what proves it succeeded
 5. **Rules section** — encode user corrections as hard rules that must be followed
 6. **Agent delegation** — only include an Agent step if the original workflow genuinely needed semantic grouping or natural language summarization. If the workflow is purely data gathering + transformation + reporting, no Agent is needed.
@@ -188,4 +189,4 @@ Output each file in a clearly marked section. The file paths are relative to the
 - **Use AskUserQuestion for user interaction** — during recovery, confirmations, and choices. The built-in "Other" option handles free-text fallback.
 - **validators.py runs first** — precondition failures should be caught before any real work starts, with clear messages about what's missing and how to fix it
 - **No inline bash complexity in SKILL.md** — never use `python3 -c "..."` with embedded code, multi-line heredocs, or complex shell pipelines in SKILL.md code blocks. These trigger Claude Code security prompts ("expansion obfuscation", "cannot be statically analyzed") that interrupt execution. Instead, put all logic in standalone Python scripts under `scripts/` and call them with simple one-line commands. Keep bash code blocks to single-line invocations like `python3 ${CLAUDE_SKILL_DIR}/scripts/foo.py "arg"`.
-- **Never write files under `~/.claude/` or `${CLAUDE_SKILL_DIR}/`** — the skill directory is discovered via a symlink from `~/.claude/skills/`, so writes there trigger sensitive-file permission prompts. Use `/tmp/{skill-name}/` for transient intermediate files (API responses, intermediate data). Write final output (reports, artifacts) to the current working directory (`$PWD`).
+- **Never write files under `~/.claude/` or `${CLAUDE_SKILL_DIR}/`** — the skill directory is discovered via a symlink from `~/.claude/skills/`, so writes there trigger sensitive-file permission prompts. For transient intermediate files (API responses, intermediate data), create an isolated workspace with `mktemp -d -t {skill-name}-XXXXXXXX` at the start of the procedure and clean it up with `rm -rf` in a final Cleanup step. Write final output (reports, artifacts) to the current working directory (`$PWD`).


### PR DESCRIPTION
## Summary

- Replace hardcoded `/tmp/skillify-*` paths with `mktemp -d -t skillify-XXXXXXXX` to create isolated workspace directories per run, preventing concurrent-run collisions
- Add a Cleanup step at the end of the procedure to remove the workspace directory
- Update generated-skill guidance in both `SKILL.md` and `prompts/generate_skill.md` to use the same `mktemp -d` pattern instead of `/tmp/{skill-name}/`

## Test plan

- [x] Verify `grep -rn '/tmp/skillify' .` returns no hits
- [x] Run `uv run pytest` — all 161 tests pass (no test changes needed, scripts only output to stdout)
- [x] Invoke `/skillify` end-to-end and confirm intermediate files are created in an isolated temp directory and cleaned up after

🤖 Generated with [Claude Code](https://claude.com/claude-code)