### PR TITLE
docs: redesign README with logo banner, badges, and tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-<h3 align="center"><em>Turn conversations into skills.</em></h3>
+<h3 align="center"><em>Conversations Are Prototypes. Skills Are Artifacts.</em></h3>
 
 <p align="center">
   <a href="https://github.com/nickommen/skillify/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/nickommen/skillify/ci.yml?branch=main&style=flat-square" alt="CI"></a>
@@ -57,13 +57,12 @@ Also triggers on natural language: "turn this into a skill", "make this a skill"
 
 1. **Identify** the source conversation — current session or explicit session UUID
 2. **Parse** the conversation JSONL into a compact workflow manifest
-3. **Supplement** with git state and project type detection for additional context
-4. **Interview** the user to confirm skill name, description, save location, and workflow steps
-5. **Check** if the conversation already produced Python scripts — reuse if possible
-6. **Generate** Python scripts, validators, and SKILL.md via an Agent reading the manifest
-7. **Preview** generated files for user confirmation before writing
-8. **Validate** generated Python syntax and YAML frontmatter
-9. **Report** created files, tool dependencies, env vars needed, and how to invoke
+3. **Interview** the user to confirm skill name, description, save location, and workflow steps
+4. **Check** if the conversation already produced Python scripts — reuse if possible
+5. **Generate** Python scripts, validators, and SKILL.md via an Agent reading the manifest
+6. **Preview** generated files for user confirmation before writing
+7. **Write and validate** generated Python syntax and YAML frontmatter
+8. **Report** created files, tool dependencies, env vars needed, and how to invoke
 
 ## Generated Skill Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
-# skillify
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/skillify-banner-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/skillify-banner-light.svg">
+    <img alt="skillify" src="assets/skillify-banner-light.svg" width="500">
+  </picture>
+</p>
 
-Convert a Claude Code conversation — where you iterated on automating a task — into a deterministic Python-scripted skill. Skillify parses the conversation JSONL, extracts the workflow (API calls, data transforms, output format), and generates Python scripts + a SKILL.md wrapper. Future runs of the generated skill are deterministic, using AI only for error recovery and semantic summarization.
+<h3 align="center"><em>Turn conversations into skills.</em></h3>
+
+<p align="center">
+  <a href="https://github.com/nickommen/skillify/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/nickommen/skillify/ci.yml?branch=main&style=flat-square" alt="CI"></a>
+  <img src="https://img.shields.io/badge/python-3.12+-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License"></a>
+</p>
+
+---
+
+Skillify converts a Claude Code conversation — where you iterated on automating a task — into a deterministic Python-scripted skill. It parses the conversation, extracts the workflow, and generates Python scripts + a SKILL.md wrapper. Future runs are deterministic, using AI only for error recovery and semantic summarization.
+
+## Prerequisites
+
+- Python 3.12+
+- Claude Code with skill support
 
 ## Installation
 
@@ -19,12 +40,6 @@ ln -sf "$(pwd)/skillify" ~/.claude/skills/skillify
 
 After installation, `/skillify` will be available in Claude Code.
 
-## Prerequisites
-
-- Python 3.12+
-- No pip dependencies — stdlib only
-- Claude Code with skill support
-
 ## Usage
 
 ```bash
@@ -40,10 +55,10 @@ Also triggers on natural language: "turn this into a skill", "make this a skill"
 
 ## How It Works
 
-1. **Identify** the source conversation — current project session or explicit session UUID
-2. **Parse** the conversation JSONL into a compact workflow manifest using `parse_conversation.py`
+1. **Identify** the source conversation — current session or explicit session UUID
+2. **Parse** the conversation JSONL into a compact workflow manifest
 3. **Supplement** with git state and project type detection for additional context
-4. **Interview** the user to confirm skill name, description, save location, and workflow steps. For non-trivial workflows, also captures preconditions, idempotency, and escalation rules.
+4. **Interview** the user to confirm skill name, description, save location, and workflow steps
 5. **Check** if the conversation already produced Python scripts — reuse if possible
 6. **Generate** Python scripts, validators, and SKILL.md via an Agent reading the manifest
 7. **Preview** generated files for user confirmation before writing
@@ -51,8 +66,6 @@ Also triggers on natural language: "turn this into a skill", "make this a skill"
 9. **Report** created files, tool dependencies, env vars needed, and how to invoke
 
 ## Generated Skill Structure
-
-When skillify generates a new skill, it creates:
 
 ```text
 skill-name/
@@ -64,42 +77,12 @@ skill-name/
   skill.schema.json     # Input/output schema (when applicable)
 ```
 
-Generated skills are designed to be:
+Generated skills are **deterministic**, **composable** (invokable via `/skill-name`), and **self-validating**.
 
-- **Deterministic** — Python scripts handle all API calls, data transforms, and formatting
-- **Composable** — other LLM sessions can invoke the skill via `/skill-name` or the `Skill` tool
-- **Self-validating** — `validators.py` checks preconditions before execution
+## Contributing
 
-## Project Structure
-
-```text
-skillify/
-  SKILL.md                          # Skillify's own skill definition
-  scripts/
-    parse_conversation.py           # JSONL conversation parser
-    parse_agent_output.py           # Agent output file extractor
-    find_session.py                 # Session JSONL resolution (pid/uuid)
-    validate_skill.py               # Generated skill validation (syntax, frontmatter)
-  prompts/
-    generate_skill.md               # Generation agent prompt template
-  tests/
-    test_parse_conversation.py      # Parser tests
-    test_parse_agent_output.py      # Agent output parser tests
-    test_find_session.py            # Session resolution tests
-    test_validate_skill.py          # Skill validation tests
-    fixtures/                       # Synthetic test data
-  install.sh                        # One-line installer
-```
-
-## Development
-
-```bash
-uv venv .venv && source .venv/bin/activate
-uv sync
-pytest --cov             # tests + coverage
-ruff check scripts/ tests/  # lint
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/assets/skillify-banner-dark.svg
+++ b/assets/skillify-banner-dark.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 400" width="100%" height="100%">
+  <g>
+  <defs>
+    <style>
+      .dark { fill: #e2e8f0; }
+      .dark-stroke { stroke: #e2e8f0; }
+      .blue { fill: #38bdf8; }
+      .blue-stroke { stroke: #38bdf8; }
+      .bg-white { fill: #1e293b; }
+    </style>
+  </defs>
+
+  <!-- Gear (Right) -->
+  <g transform="translate(260, 200)">
+    <g class="blue-stroke" stroke-width="22" stroke-linecap="round">
+      <line x1="0" y1="-65" x2="0" y2="-78" />
+      <line x1="0" y1="65" x2="0" y2="78" />
+      <line x1="-65" y1="0" x2="-78" y2="0" />
+      <line x1="65" y1="0" x2="78" y2="0" />
+      <line x1="-46" y1="-46" x2="-55" y2="-55" />
+      <line x1="46" y1="46" x2="55" y2="55" />
+      <line x1="-46" y1="46" x2="-55" y2="55" />
+      <line x1="46" y1="-46" x2="55" y2="-55" />
+    </g>
+    <circle cx="0" cy="0" r="65" fill="none" class="blue-stroke" stroke-width="22"/>
+  </g>
+
+  <!-- Document (Center) -->
+  <rect x="145" y="60" width="130" height="280" rx="18" class="bg-white dark-stroke" stroke-width="18" stroke-linejoin="round"/>
+
+  <!-- Document Content: Code Lines -->
+  <g class="blue-stroke" stroke-width="12" stroke-linecap="round">
+    <!-- Top block -->
+    <line x1="175" y1="110" x2="195" y2="110" />
+    <line x1="215" y1="110" x2="245" y2="110" class="dark-stroke" />
+    <line x1="175" y1="145" x2="235" y2="145" />
+    <line x1="175" y1="180" x2="205" y2="180" class="dark-stroke" />
+    <!-- Bottom block -->
+    <line x1="175" y1="290" x2="205" y2="290" />
+    <line x1="225" y1="290" x2="245" y2="290" class="dark-stroke" />
+  </g>
+  <!-- Checkmark -->
+  <path d="M 175 235 L 205 265 L 255 195" fill="none" class="dark-stroke" stroke-width="20" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Left Side: Chat Bubbles and converging paths -->
+  <!-- Top Bubble -->
+  <g transform="translate(60, 80)">
+    <path d="M 10 0 h 30 a 10 10 0 0 1 10 10 v 20 a 10 10 0 0 1 -10 10 h -10 l -10 15 v -15 h -20 a 10 10 0 0 1 -10 -10 v -20 a 10 10 0 0 1 10 -10 z" class="blue"/>
+    <circle cx="20" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="30" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="40" cy="20" r="3.5" class="bg-white"/>
+  </g>
+
+  <!-- Bottom Bubble -->
+  <g transform="translate(70, 240)">
+    <path d="M 10 0 h 30 a 10 10 0 0 1 10 10 v 20 a 10 10 0 0 1 -10 10 h -20 l -10 15 v -15 h -10 a 10 10 0 0 1 -10 -10 v -20 a 10 10 0 0 1 10 -10 z" class="dark"/>
+    <circle cx="20" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="30" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="40" cy="20" r="3.5" class="bg-white"/>
+  </g>
+
+  <!-- Braces -->
+  <text x="100" y="210" font-family="'Courier New', Courier, monospace" font-size="64" font-weight="900" class="dark" text-anchor="middle">{}</text>
+
+  <!-- Converging arrows/lines -->
+  <g fill="none" class="blue-stroke" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <!-- from top bubble -->
+    <path d="M 120 110 C 145 110, 130 160, 155 160" />
+    <path d="M 140 145 L 160 160 L 140 175" />
+
+    <!-- from braces -->
+    <line x1="125" y1="195" x2="155" y2="195" />
+    <path d="M 140 180 L 160 195 L 140 210" />
+
+    <!-- from bottom bubble -->
+    <path d="M 130 260 C 150 260, 135 230, 155 230" />
+    <path d="M 140 215 L 160 230 L 140 245" />
+  </g>
+
+  <!-- Accent Dots and Lines -->
+  <circle cx="40" cy="195" r="7" class="blue"/>
+  <line x1="40" y1="195" x2="65" y2="195" class="blue-stroke" stroke-width="8" stroke-linecap="round"/>
+
+  <circle cx="120" cy="65" r="5" class="dark"/>
+  <circle cx="130" cy="290" r="6" class="blue"/>
+  <circle cx="60" cy="310" r="5" class="dark"/>
+  <circle cx="40" cy="130" r="4" class="dark"/>
+</g>
+  <text x="390" y="245" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="160" font-weight="800" fill="#e2e8f0" letter-spacing="-3">skillify</text>
+</svg>

--- a/assets/skillify-banner-light.svg
+++ b/assets/skillify-banner-light.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 400" width="100%" height="100%">
+  <g>
+  <defs>
+    <style>
+      .dark { fill: #0f172a; }
+      .dark-stroke { stroke: #0f172a; }
+      .blue { fill: #0284c7; }
+      .blue-stroke { stroke: #0284c7; }
+      .bg-white { fill: #ffffff; }
+    </style>
+  </defs>
+
+  <!-- Gear (Right) -->
+  <g transform="translate(260, 200)">
+    <g class="blue-stroke" stroke-width="22" stroke-linecap="round">
+      <line x1="0" y1="-65" x2="0" y2="-78" />
+      <line x1="0" y1="65" x2="0" y2="78" />
+      <line x1="-65" y1="0" x2="-78" y2="0" />
+      <line x1="65" y1="0" x2="78" y2="0" />
+      <line x1="-46" y1="-46" x2="-55" y2="-55" />
+      <line x1="46" y1="46" x2="55" y2="55" />
+      <line x1="-46" y1="46" x2="-55" y2="55" />
+      <line x1="46" y1="-46" x2="55" y2="-55" />
+    </g>
+    <circle cx="0" cy="0" r="65" fill="none" class="blue-stroke" stroke-width="22"/>
+  </g>
+
+  <!-- Document (Center) -->
+  <rect x="145" y="60" width="130" height="280" rx="18" class="bg-white dark-stroke" stroke-width="18" stroke-linejoin="round"/>
+  
+  <!-- Document Content: Code Lines -->
+  <g class="blue-stroke" stroke-width="12" stroke-linecap="round">
+    <!-- Top block -->
+    <line x1="175" y1="110" x2="195" y2="110" />
+    <line x1="215" y1="110" x2="245" y2="110" class="dark-stroke" />
+    <line x1="175" y1="145" x2="235" y2="145" />
+    <line x1="175" y1="180" x2="205" y2="180" class="dark-stroke" />
+    <!-- Bottom block -->
+    <line x1="175" y1="290" x2="205" y2="290" />
+    <line x1="225" y1="290" x2="245" y2="290" class="dark-stroke" />
+  </g>
+  <!-- Checkmark -->
+  <path d="M 175 235 L 205 265 L 255 195" fill="none" class="dark-stroke" stroke-width="20" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Left Side: Chat Bubbles and converging paths -->
+  <!-- Top Bubble -->
+  <g transform="translate(60, 80)">
+    <path d="M 10 0 h 30 a 10 10 0 0 1 10 10 v 20 a 10 10 0 0 1 -10 10 h -10 l -10 15 v -15 h -20 a 10 10 0 0 1 -10 -10 v -20 a 10 10 0 0 1 10 -10 z" class="blue"/>
+    <circle cx="20" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="30" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="40" cy="20" r="3.5" class="bg-white"/>
+  </g>
+  
+  <!-- Bottom Bubble -->
+  <g transform="translate(70, 240)">
+    <path d="M 10 0 h 30 a 10 10 0 0 1 10 10 v 20 a 10 10 0 0 1 -10 10 h -20 l -10 15 v -15 h -10 a 10 10 0 0 1 -10 -10 v -20 a 10 10 0 0 1 10 -10 z" class="dark"/>
+    <circle cx="20" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="30" cy="20" r="3.5" class="bg-white"/>
+    <circle cx="40" cy="20" r="3.5" class="bg-white"/>
+  </g>
+
+  <!-- Braces -->
+  <text x="100" y="210" font-family="'Courier New', Courier, monospace" font-size="64" font-weight="900" class="dark" text-anchor="middle">{}</text>
+
+  <!-- Converging arrows/lines -->
+  <g fill="none" class="blue-stroke" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <!-- from top bubble -->
+    <path d="M 120 110 C 145 110, 130 160, 155 160" />
+    <path d="M 140 145 L 160 160 L 140 175" />
+    
+    <!-- from braces -->
+    <line x1="125" y1="195" x2="155" y2="195" />
+    <path d="M 140 180 L 160 195 L 140 210" />
+
+    <!-- from bottom bubble -->
+    <path d="M 130 260 C 150 260, 135 230, 155 230" />
+    <path d="M 140 215 L 160 230 L 140 245" />
+  </g>
+  
+  <!-- Accent Dots and Lines -->
+  <circle cx="40" cy="195" r="7" class="blue"/>
+  <line x1="40" y1="195" x2="65" y2="195" class="blue-stroke" stroke-width="8" stroke-linecap="round"/>
+
+  <circle cx="120" cy="65" r="5" class="dark"/>
+  <circle cx="130" cy="290" r="6" class="blue"/>
+  <circle cx="60" cy="310" r="5" class="dark"/>
+  <circle cx="40" cy="130" r="4" class="dark"/>
+</g>
+  <text x="390" y="245" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="160" font-weight="800" fill="#0f172a" letter-spacing="-3">skillify</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add centered SVG logo banner with automatic light/dark mode switching via `<picture>` element
- Add shields.io badges: CI status, Python 3.12+, MIT license
- Add tagline: "Turn conversations into skills."
- Streamline content — remove Project Structure and Development sections (already in CONTRIBUTING.md)
- Tighten copy throughout

## Test plan

- [x] Verify logo renders on GitHub in both light and dark mode (Settings → Appearance)
- [ ] Verify all three badges render and link correctly
- [x] Verify CONTRIBUTING.md and LICENSE links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)