### PR TITLE
chore: add defensive gitignore patterns for secrets and keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ __pycache__/
 .coverage
 .pytest_cache/
 .ruff_cache/
+
+.env
+.env.*
+*.pem
+*.key
+credentials.json
+secrets.json


### PR DESCRIPTION
## Summary

- Add `.env` and `.env.*` patterns to prevent accidental secret leaks
- Add `*.pem` and `*.key` for private key files
- Add `credentials.json` and `secrets.json` for credential files

Defensive hardening before making the repo public.

## Test plan

- [x] Verify no tracked files are affected by the new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)