### PR TITLE
chore: release v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skillify"
-version = "0.2.0"
+version = "0.3.0"
 description = "Convert Claude Code conversations into deterministic Python-scripted skills"
 requires-python = ">=3.12"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "skillify"
-version = "0.1.0"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bumps version from 0.2.0 to 0.3.0
- Captures all changes since v0.2.0: defensive gitignore patterns (#23), Docusaurus documentation site (#24), and introductory blog post (#25)

## What's in 0.3.0

- **chore**: Defensive `.gitignore` patterns for secrets and keys (#23)
- **docs**: Docusaurus documentation site with GitHub Pages deployment (#24)
- **docs**: Introductory blog post — "Conversations Are Prototypes, Skills Are Artifacts" (#25)

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 161 tests pass
- [x] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)